### PR TITLE
redis >= 2.6.12 required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ TODO
 Requirements
 ============
 
-Redis 2.6 or later.
+Redis 2.6.12 or later.
 
 Python 2.6, 2.7, 3.2, 3.3 and PyPy are supported.
 


### PR DESCRIPTION
According to http://redis.io/commands/set the `SET` type added the `ex` argument at redis 2.6.12.

I am testing with redis 2.6.7, and I get the following error:

``` python
from django.core.cache import cache
with cache.lock('hello'):
    print 'I got the lock'
...:     
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-e20c4f841145> in <module>()
----> 1 with cache.lock('me'):
      2     print 'got the lock'
      3 

.../lib/python2.7/site-packages/redis_lock/__init__.pyc in __enter__(self, blocking)
     37         busy = True
     38         while busy:
---> 39             busy = not self._client.set(self._name, self._tok, nx=True, ex=self._expire)
     40             if busy:
     41                 if blocking:

TypeError: set() got an unexpected keyword argument 'ex'
```
