### PR TITLE
Fix bogus keyword argument passed to django_redis's DefaultClient.

### DIFF
--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -36,7 +36,7 @@ class Lock(object):
 
         busy = True
         while busy:
-            busy = not self._client.set(self._name, self._tok, nx=True, ex=self._expire)
+            busy = not self._client.set(self._name, self._tok, nx=True, timeout=self._expire)
             if busy:
                 if blocking:
                     self._client.blpop(self._signal, self._expire or 0)


### PR DESCRIPTION
Hi :-)
I ran into an issue using your lock implementation today. The keyword argument (`ex`) used to inform the timeout duration to django_redis's DefaultClient doesn't exist in the function definition. I checked earlier versions of django_redis to see whether the issue could have been caused by a version incompatibility, but it seems that the `ex` kwarg never existed. Please, could you verify?
