### PR TITLE
Add an option to refresh the lock automatically

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,11 +139,19 @@ You would write your functions like this::
 
 
 Troubleshooting
-------------------------------
+---------------
 
 In some cases, the lock remains in redis forever (like a server blackout / redis or application crash / an unhandled
-exception). In such cases, the lock is not removed by restarting the application. One solution is to use the
-``reset_all()`` function when the application starts::
+exception). In such cases, the lock is not removed by restarting the application. One solution is to set the
+`refresh_interval` in combination with `expire` to set a time-out on the lock, but let `Lock()` automatically
+keep refreshing the expire time while your application code is executing::
+
+    # Expire the lock after 60 seconds, but keep refreshing it every 30 seconds
+    # to ensure the lock is held for as long as the Python process is running.
+    with redis_lock.Lock('my-lock', expire=60, refresh_interval=30):
+        # Do work....
+
+Another solution is to use the ``reset_all()`` function when the application starts::
 
     # On application start/restart
     import redis_lock
@@ -159,6 +167,7 @@ Features
 
 * based on the standard SETNX recipe
 * optional expiry
+* optional lock refreshing (use a low expire but keep the lock active)
 * no spinloops at acquire
 
 Implementation

--- a/README.rst
+++ b/README.rst
@@ -143,12 +143,12 @@ Troubleshooting
 
 In some cases, the lock remains in redis forever (like a server blackout / redis or application crash / an unhandled
 exception). In such cases, the lock is not removed by restarting the application. One solution is to set the
-`refresh_interval` in combination with `expire` to set a time-out on the lock, but let `Lock()` automatically
-keep refreshing the expire time while your application code is executing::
+`renewal` parameter in combination with `expire` to set a time-out on the lock, but let `Lock()` automatically
+keep resetting the expire time while your application code is executing::
 
-    # Expire the lock after 60 seconds, but keep refreshing it every 30 seconds
+    # Expire the lock after 60 seconds, but keep renewing it every 30 seconds
     # to ensure the lock is held for as long as the Python process is running.
-    with redis_lock.Lock('my-lock', expire=60, refresh_interval=30):
+    with redis_lock.Lock('my-lock', expire=60, renewal=30):
         # Do work....
 
 Another solution is to use the ``reset_all()`` function when the application starts::
@@ -167,7 +167,7 @@ Features
 
 * based on the standard SETNX recipe
 * optional expiry
-* optional lock refreshing (use a low expire but keep the lock active)
+* optional lock renewal (use a low expire but keep the lock active)
 * no spinloops at acquire
 
 Implementation

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ exception). In such cases, the lock is not removed by restarting the application
 `auto_renewal` parameter in combination with `expire` to set a time-out on the lock, but let `Lock()` automatically
 keep resetting the expire time while your application code is executing::
 
-    # Expire the lock after 60 seconds, but keep renewing it every 30 seconds
+    # Get a lock with a 60-second lifetime but keep renewing it automatically
     # to ensure the lock is held for as long as the Python process is running.
     with redis_lock.Lock('my-lock', expire=60, auto_renewal=True):
         # Do work....

--- a/README.rst
+++ b/README.rst
@@ -142,13 +142,13 @@ Troubleshooting
 ---------------
 
 In some cases, the lock remains in redis forever (like a server blackout / redis or application crash / an unhandled
-exception). In such cases, the lock is not removed by restarting the application. One solution is to set the
-`renewal` parameter in combination with `expire` to set a time-out on the lock, but let `Lock()` automatically
+exception). In such cases, the lock is not removed by restarting the application. One solution is to turn on the
+`auto_renewal` parameter in combination with `expire` to set a time-out on the lock, but let `Lock()` automatically
 keep resetting the expire time while your application code is executing::
 
     # Expire the lock after 60 seconds, but keep renewing it every 30 seconds
     # to ensure the lock is held for as long as the Python process is running.
-    with redis_lock.Lock('my-lock', expire=60, renewal=30):
+    with redis_lock.Lock('my-lock', expire=60, auto_renewal=True):
         # Do work....
 
 Another solution is to use the ``reset_all()`` function when the application starts::

--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -188,7 +188,12 @@ class InterruptableThread(threading.Thread):
         If timeout is specified (as a float of seconds to wait) then wait
         up to this many seconds before returning the value of `should_exit`.
         """
-        return self._should_exit.wait(timeout)
+        should_exit = self._should_exit.wait(timeout)
+        if should_exit is None:
+            # Python 2.6 compatibility which doesn't return self.__flag when
+            # calling Event.wait()
+            should_exit = self.should_exit
+        return should_exit
 
 
 def reset_all(redis_client):

--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -131,7 +131,7 @@ class Lock(object):
 
     def _stop_lock_refresher(self):
         """Stop the lock refresher"""
-        if self._lock_refresh_thread is None:
+        if self._lock_refresh_thread is None or not self._lock_refresh_thread.is_alive():
             return
         logger.debug("Signalling the lock refresher to stop")
         self._lock_refresh_thread.request_exit()

--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -106,7 +106,7 @@ class Lock(object):
 
         logger.debug("Got lock for %r.", self._name)
         self._held = True
-        if self._lock_renewal_interval > 0:
+        if self._lock_renewal_interval is not None:
             self._start_lock_renewer()
         return True
 

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -189,18 +189,26 @@ def test_release_from_nonblocking_leaving_garbage(conn):
         lock.release()
         assert conn.llen('lock-signal:release_from_nonblocking') == 1
 
-def test_lock_refresher(conn):
-    lock = Lock(conn, 'lock_refresher', expire=3, renewal=0)
+def test_no_auto_renewal(conn):
+    lock = Lock(conn, 'lock_renewal', expire=3, auto_renewal=False)
+    assert lock._lock_renewal_interval is None
     lock.acquire()
     assert lock._lock_renewal_thread is None, "No lock refresh thread should have been spawned"
 
-    lock = Lock(conn, 'lock_refresher', expire=3, renewal=1)
+def test_auto_renewal_bad_values(conn):
+    with pytest.raises(ValueError):
+        Lock(conn, 'lock_renewal', expire=None, auto_renewal=True)
+
+def test_auto_renewal(conn):
+    lock = Lock(conn, 'lock_renewal', expire=3, auto_renewal=True)
     lock.acquire()
+
     assert isinstance(lock._lock_renewal_thread, InterruptableThread)
     assert not lock._lock_renewal_thread.should_exit
+    assert lock._lock_renewal_interval == 2
 
     time.sleep(3)
-    assert conn.get(lock._name) == lock.id, "Key expired but it should have been getting refreshed"
+    assert conn.get(lock._name) == lock.id, "Key expired but it should have been getting renewed"
 
     lock.release()
     assert lock._lock_renewal_thread is None

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -190,17 +190,17 @@ def test_release_from_nonblocking_leaving_garbage(conn):
         assert conn.llen('lock-signal:release_from_nonblocking') == 1
 
 def test_lock_refresher(conn):
-    lock = Lock(conn, 'lock_refresher', expire=3, refresh_interval=0)
+    lock = Lock(conn, 'lock_refresher', expire=3, renewal=0)
     lock.acquire()
-    assert lock._lock_refresh_thread is None, "No lock refresh thread should have been spawned"
+    assert lock._lock_renewal_thread is None, "No lock refresh thread should have been spawned"
 
-    lock = Lock(conn, 'lock_refresher', expire=3, refresh_interval=1)
+    lock = Lock(conn, 'lock_refresher', expire=3, renewal=1)
     lock.acquire()
-    assert isinstance(lock._lock_refresh_thread, InterruptableThread)
-    assert not lock._lock_refresh_thread.should_exit
+    assert isinstance(lock._lock_renewal_thread, InterruptableThread)
+    assert not lock._lock_renewal_thread.should_exit
 
     time.sleep(3)
     assert conn.get(lock._name) == lock.id, "Key expired but it should have been getting refreshed"
 
     lock.release()
-    assert lock._lock_refresh_thread is None
+    assert lock._lock_renewal_thread is None


### PR DESCRIPTION
This introduces a new parameter `refresh_interval` which, when set to a
value > 0 triggers the creation of a subthread that will re-set the
expire time of the lock.

This allows one to use a relatively low expires time but keep the lock
active in Redis for as long as the lock is acquired in Python code,
avoiding the stale lock issue when a Python process is killed abruptly
without a chance to release the lock in Redis.