### PR TITLE
Document Lock.release method

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,9 +34,30 @@ Non-blocking lock::
     else:
         print("Someone else has the lock.")
 
-Controlled execution lock::
+Releasing previously acquired lock::
+
+    conn = StrictRedis()
+    lock = redis_lock.Lock(conn, "name-of-the-lock")
+    lock.acquire()
+    print("Got the lock. Doing some work ...")
+    time.sleep(5)
+    lock.release()
+
+The above example could be rewritten using context manager::
 
     conn = StrictRedis()
     with redis_lock.Lock(conn, "name-of-the-lock"):
         print("Got the lock. Doing some work ...")
         time.sleep(5)
+
+In cases, where lock not necessarily in acquired state, and
+user need to ensure, that it's released, ``force`` parameter could be used::
+
+    lock = Lock(conn, "foo")
+    try:
+      if lock.acquire(block=False):
+        print("Got the lock. Do crazy dance")
+      else:
+        print("Didn't get the lock. Do normal dance")
+    finally:
+      lock.release(force=True)

--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -205,6 +205,13 @@ class Lock(object):
         self._held = False
 
     def release(self, force=False):
+        """Releases the lock, that was acquired in the same Python context.
+
+        :param force:
+            If ``False`` - fail with exception if this instance was not in
+            acquired state in the same Python context.
+            If ``True`` - fail silently.
+        """
         return self.__exit__(force=force)
 
 


### PR DESCRIPTION
I noticed lack of documentation for release() method, this PR fixes it.