### PR TITLE
Introduce immediate expiration of signal-keys

### DIFF
--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -14,6 +14,7 @@ UNLOCK_SCRIPT = b"""
     if redis.call("get", KEYS[1]) == ARGV[1] then
         redis.call("del", KEYS[2])
         redis.call("lpush", KEYS[2], 1)
+        redis.call("expire", KEYS[2], 1)
         return redis.call("del", KEYS[1])
     else
         return 0

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -277,3 +277,12 @@ def test_auto_renewal(conn):
 
     lock.release()
     assert lock._lock_renewal_thread is None
+
+
+def test_signal_expiration(conn):
+    """Signal keys expire within two seconds after releasing the lock."""
+    lock = Lock(conn, 'signal_expiration')
+    lock.acquire()
+    lock.release()
+    time.sleep(2)
+    assert conn.llen('lock-signal:signal_expiration') == 0


### PR DESCRIPTION
Signal keys are needed to let know about release to waiters that are
already awaiting of it, therefore, the signal key can be removed
(or expired) immediately after waiters was notified.

Fixes #17.

There are some tests, that failing and I don't really understand their purpose, can somebody explain their meaning?