### PR TITLE
Replace EXPIRE with PEXPIRE calls for expiration of signal-lists

### DIFF
--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -17,7 +17,7 @@ UNLOCK_SCRIPT = b"""
     else
         redis.call("del", KEYS[2])
         redis.call("lpush", KEYS[2], 1)
-        redis.call("expire", KEYS[2], 1)
+        redis.call("pexpire", KEYS[2], 1)
         redis.call("del", KEYS[1])
         return 0
     end
@@ -40,7 +40,7 @@ EXTEND_SCRIPT_HASH = sha1(EXTEND_SCRIPT).hexdigest()
 RESET_SCRIPT = b"""
     redis.call('del', KEYS[2])
     redis.call('lpush', KEYS[2], 1)
-    redis.call('expire', KEYS[2], 1)
+    redis.call('pexpire', KEYS[2], 1)
     return redis.call('del', KEYS[1])
 """
 
@@ -53,7 +53,7 @@ RESET_ALL_SCRIPT = b"""
         signal = 'lock-signal:' .. string.sub(lock, 6)
         redis.call('del', signal)
         redis.call('lpush', signal, 1)
-        redis.call('expire', signal, 1)
+        redis.call('pexpire', signal, 1)
         redis.call('del', lock)
     end
     return #locks

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
             with Lock(conn, "foobar"):
                 time.sleep(0.001)
         sched.enterabs(start, 0, cb_no_overlap, ())
-        pids = []
+        pids = [os.getpid()]
 
         for _ in range(125):
             pid = os.fork()

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -408,14 +408,6 @@ def test_bogus_release(conn):
     lock2.release()
 
 
-def test_release_from_nonblocking_leaving_garbage(conn):
-    for _ in range(10):
-        lock = Lock(conn, 'release_from_nonblocking')
-        lock.acquire(blocking=False)
-        lock.release()
-        assert conn.llen('lock-signal:release_from_nonblocking') == 1
-
-
 def test_no_auto_renewal(conn):
     lock = Lock(conn, 'lock_renewal', expire=3, auto_renewal=False)
     assert lock._lock_renewal_interval is None

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -436,11 +436,11 @@ def test_auto_renewal(conn):
 
 
 def test_signal_expiration(conn):
-    """Signal keys expire within two seconds after releasing the lock."""
+    """Signal keys expire after one millisecond after releasing the lock."""
     lock = Lock(conn, 'signal_expiration')
     lock.acquire()
     lock.release()
-    time.sleep(2)
+    time.sleep(0.002)
     assert conn.llen('lock-signal:signal_expiration') == 0
 
 


### PR DESCRIPTION
Subj. It will reduce expiration time of lists from a second to one millisecond.