### PR TITLE
Do not timeout without timeout

### DIFF
--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -195,7 +195,7 @@ class Lock(object):
                 if timed_out:
                     return False
                 elif blocking:
-                    timed_out = not self._client.blpop(self._signal, blpop_timeout)
+                    timed_out = not self._client.blpop(self._signal, blpop_timeout) and timeout
                 else:
                     logger.debug("Failed to get %r.", self._name)
                     return False

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -170,6 +170,15 @@ def test_expire(conn):
         lock.release()
 
 
+def test_expire_without_timeout(conn):
+    first_lock = Lock(conn, 'expire', expire=2)
+    second_lock = Lock(conn, 'expire', expire=1)
+    first_lock.acquire()
+    assert second_lock.acquire(blocking=False) is False
+    assert second_lock.acquire() is True
+    second_lock.release()
+
+
 def test_extend(conn):
     name = 'foobar'
     key_name = 'lock:' + name


### PR DESCRIPTION
I have a system where I use python-redis-lock to synchronize my workers. I use `expire=60` together with `auto_renewal=True`. If process does not release the lock within 60 seconds, waiting thread throws an error. This is not what I want. I want waiting thread to wait indefinitely until lock is released or lock expires (implying that worker, which had the lock, crashed).

I could increase `expire`, but it would delay recovery from worker failure and would not be scalable.

I changed code to only timeout when timeout is specified.

How to reproduce the problem:
```
from redis_lock import Lock
lock = Lock(redis_client=redis, name='expire', expire=60, auto_renewal=True)
lock.acquire()
```
with other window:
```
from redis_lock import Lock
lock = Lock(redis_client=redis, name='expire', expire=60, auto_renewal=True)
with lock:
    print('got lock')
```

