### PR TITLE
Add get_or_set_locked convenience method to Django cache backend

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Authors
 * Victor Torres - http://github.com/victor-torres
 * Andrew Pashkin - https://github.com/AndrewPashkin
 * Tero Vuotila - https://github.com/tvuotila
+* Joel Höner - https://github.com/athre0z

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Changelog
 * Allow locks with given `id` to acquire. Previously it assumed that if you specify the `id` then the lock was already
   acquired. See `#44 <https://github.com/ionelmc/python-redis-lock/issues/44>`_ and
   `#39 <https://github.com/ionelmc/python-redis-lock/issues/39>`_.
-* Added convenience method `get_or_set_locked` to Django cache backend. 
+* Added convenience method `locked_get_or_set` to Django cache backend.
 
 3.1.0 (2016-04-16)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 * Allow locks with given `id` to acquire. Previously it assumed that if you specify the `id` then the lock was already
   acquired. See `#44 <https://github.com/ionelmc/python-redis-lock/issues/44>`_ and
   `#39 <https://github.com/ionelmc/python-redis-lock/issues/39>`_.
+* Added convenience method `get_or_set_locked` to Django cache backend. 
 
 3.1.0 (2016-04-16)
 ------------------

--- a/src/redis_lock/django_cache.py
+++ b/src/redis_lock/django_cache.py
@@ -20,7 +20,7 @@ class RedisCache(PlainRedisCache):
     def lock(self, key, expire=None, id=None):
         return Lock(self.__client, key, expire=expire, id=id)
 
-    def get_or_set_locked(self, key, value_creator, version=None,
+    def locked_get_or_set(self, key, value_creator, version=None,
                           expire=None, id=None, lock_key=None,
                           timeout=DEFAULT_TIMEOUT):
         """

--- a/src/redis_lock/django_cache.py
+++ b/src/redis_lock/django_cache.py
@@ -29,7 +29,7 @@ class RedisCache(PlainRedisCache):
         is invoked inside of a lock.
         """
         if lock_key is None:
-            lock_key = '{0}.set-lock'.format(key)
+            lock_key = 'get_or_set:' + key
 
         val = self.get(key, version=version)
         if val is not None:

--- a/src/redis_lock/django_cache.py
+++ b/src/redis_lock/django_cache.py
@@ -1,3 +1,4 @@
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django_redis.cache import RedisCache as PlainRedisCache
 
 from redis_lock import Lock
@@ -18,6 +19,36 @@ class RedisCache(PlainRedisCache):
 
     def lock(self, key, expire=None, id=None):
         return Lock(self.__client, key, expire=expire, id=id)
+
+    def get_or_set_locked(self, key, value_creator, version=None,
+                          expire=None, id=None, lock_key=None,
+                          timeout=DEFAULT_TIMEOUT):
+        """
+        Fetch a given key from the cache. If the key does not exist, the key is added and
+        set to the value returned when calling `value_creator`. The creator function
+        is invoked inside of a lock.
+        """
+        # As users might put `None` into the cache, we need something
+        # uniquely recognizable for our `default` argument to `.get`.
+        not_set = object()
+
+        if lock_key is None:
+            lock_key = '{0}.set-lock'.format(key)
+
+        val = self.get(key, version=version, default=not_set)
+        if val is not not_set:
+            return val
+        else:
+            with self.lock(lock_key, expire=expire, id=id):
+                # Was the value set while we were trying to acquire the lock?
+                val = self.get(key, version=version, default=not_set)
+                if val is not not_set:
+                    return val
+
+                # Nope, create value now.
+                val = value_creator()
+                self.set(key, val, timeout=timeout, version=version)
+                return val
 
     def reset_all(self):
         """

--- a/tests/test_django_integration.py
+++ b/tests/test_django_integration.py
@@ -25,11 +25,11 @@ def test_django_add_or_set_locked(redis_server):
     def assert_false_creator():
         assert False
 
-    assert cache.get_or_set_locked("foobar-aosl", creator_42) == 42
-    assert cache.get_or_set_locked("foobar-aosl", assert_false_creator) == 42
+    assert cache.locked_get_or_set("foobar-aosl", creator_42) == 42
+    assert cache.locked_get_or_set("foobar-aosl", assert_false_creator) == 42
 
     try:
-        val = cache.get_or_set_locked("foobar-aosl2", none_creator)
+        val = cache.locked_get_or_set("foobar-aosl2", none_creator)
     except ValueError:
         pass
     else:

--- a/tests/test_django_integration.py
+++ b/tests/test_django_integration.py
@@ -15,6 +15,28 @@ def test_django_works(redis_server):
 
 
 @pytest.mark.skipif("not django")
+def test_django_add_or_set_locked(redis_server):
+    def creator_42():
+        return 42
+
+    def none_creator():
+        return None
+
+    def assert_false_creator():
+        assert False
+
+    assert cache.get_or_set_locked("foobar-aosl", creator_42) == 42
+    assert cache.get_or_set_locked("foobar-aosl", assert_false_creator) == 42
+
+    try:
+        val = cache.get_or_set_locked("foobar-aosl2", none_creator)
+    except ValueError:
+        pass
+    else:
+        assert False
+
+
+@pytest.mark.skipif("not django")
 def test_reset_all(redis_server):
     lock1 = cache.lock("foobar1")
     lock2 = cache.lock("foobar2")


### PR DESCRIPTION
This PR adds a locked version of the `get_or_set` cache method that was introduced in Django 1.9 (without depending on it). I found myself repeating this code all over my project and thought it might also be relevant to other users in a Django environment.