### PR TITLE
Replace method `warn` with `warning` in logging

### DIFF
--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -124,7 +124,7 @@ def _eval_script(redis, script_id, *keys, **kwargs):
     try:
         return redis.evalsha(SCRIPTS[script_id], len(keys), *keys + args)
     except NoScriptError:
-        logger.warn("%s not cached.", SCRIPTS[script_id + 2])
+        logger.warning("%s not cached.", SCRIPTS[script_id + 2])
         return redis.eval(SCRIPTS[script_id + 1], len(keys), *keys + args)
 
 


### PR DESCRIPTION
Since Python 3.3, `Logger.warn` causes a `DeprecationWarning` (https://github.com/python/cpython/blob/3.3/Lib/logging/__init__.py#L1251). `Logger.warning` works in both Python 2 (https://docs.python.org/2/library/logging.html#logging.Logger.warning) and Python 3 (https://docs.python.org/3.5/library/logging.html#logging.Logger.warning). 

More information here: http://stackoverflow.com/questions/15539937/whats-the-difference-between-logging-warn-and-logging-warning-in-python-or-are