### PR TITLE
Allow passing `auto_renew` argument to Django cache instance

### DIFF
--- a/src/redis_lock/django_cache.py
+++ b/src/redis_lock/django_cache.py
@@ -17,7 +17,7 @@ class RedisCache(PlainRedisCache):
             )
 
     def lock(self, key, expire=None, id=None):
-        return Lock(self.__client, key, expire=expire, id=id)
+        return Lock(self.__client, key, expire=expire, id=id, auto_renewal=False)
 
     def reset_all(self):
         """

--- a/src/redis_lock/django_cache.py
+++ b/src/redis_lock/django_cache.py
@@ -16,8 +16,8 @@ class RedisCache(PlainRedisCache):
                 "Use 'redis_cache.client.DefaultClient' as the CLIENT_CLASS !" % exc
             )
 
-    def lock(self, key, expire=None, id=None):
-        return Lock(self.__client, key, expire=expire, id=id, auto_renewal=False)
+    def lock(self, key, expire=None, id=None, auto_renewal=False):
+        return Lock(self.__client, key, expire=expire, id=id, auto_renewal=auto_renewal)
 
     def reset_all(self):
         """


### PR DESCRIPTION
I've had this around for a long time, just deciding to contribute.