### PR TITLE
Lower the level of "{script} not cached." log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+3.3.0 (???)
+------------------
+
+* "%(script)s not cached" log is not logged as a warning anymore. INFO log level is used instead.
+
 3.2.0 (2016-10-29)
 ------------------
 

--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -124,7 +124,7 @@ def _eval_script(redis, script_id, *keys, **kwargs):
     try:
         return redis.evalsha(SCRIPTS[script_id], len(keys), *keys + args)
     except NoScriptError:
-        logger.warn("%s not cached.", SCRIPTS[script_id + 2])
+        logger.info("%s not cached.", SCRIPTS[script_id + 2])
         return redis.eval(SCRIPTS[script_id + 1], len(keys), *keys + args)
 
 


### PR DESCRIPTION
It's nothing abnormal nor actionable. It can be just an info log instead.