### PR TITLE
release 3.2.1 - use uuid4 for id instead of urandom

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*names, **kwargs):
 
 setup(
     name='python-redis-lock',
-    version='3.2.0',
+    version='3.2.1',
     license='BSD',
     description='Lock context manager implemented via redis SETNX/BLPOP.',
     long_description='%s\n%s' % (

--- a/src/redis_lock/__init__.py
+++ b/src/redis_lock/__init__.py
@@ -1,13 +1,13 @@
 import threading
 from logging import getLogger
-from os import urandom
 from hashlib import sha1
+import uuid
 import weakref
 
 from redis import StrictRedis
 from redis.exceptions import NoScriptError
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 logger = getLogger(__name__)
 
@@ -169,7 +169,7 @@ class Lock(object):
         self._client = redis_client
         self._expire = expire if expire is None else int(expire)
         if id is None:
-            self._id = urandom(16)
+            self._id = uuid.uuid4().hex.encode('utf-8')
         elif isinstance(id, bytes):
             self._id = id
         else:


### PR DESCRIPTION
## Summary
This is a fix for #57 that simply uses `uuid.uuid4` generated `bytes` objects instead of `urandom` bytes objects. These values should be opaque to clients, hence the patch version bump. The reason for including the `encode('utf-8')` call is for Python 3, to ensure the type of `self._id` remains `bytes`.