### PR TITLE
Move to slightly more flexible logging scheme.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Authors
 * Julien Heller - https://github.com/flux627
 * Przemysław Suliga - https://github.com/suligap
 * Artem Slobodkin - https://github.com/artslob
+* Salomon Smeke Cohen - https://github.com/SalomonSmeke

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -62,3 +62,8 @@ To check if lock with same name is already locked
 (it can be this or another lock with identical names)::
 
     is_locked = Lock(conn, "lock-name").locked()
+
+You can control the log output by modifying various loggers::
+
+    logging.getLogger("redis_lock.thread").disabled = True
+    logging.getLogger("redis_lock").disable(logging.DEBUG)


### PR DESCRIPTION
https://github.com/ionelmc/python-redis-lock/issues/78

- Make loggers for specific actions/types.
- Change log levels to match issue#78.
- Add logging information to usage docs.

Notes:

- Did not add to readme, as it seems like condensed usage. This is certainly not a necessary/basic feature.
- If this is approved ill add myself to AUTHORS.rst as a separate commit.
- Tox was spewing redis errors left and right that did not seem related. I fixed a style complaint (ln 297) but will rely on Travis
for the rest. I see that some tests call `wait_for_strings` which is relevant to this piece; but as far as I understand the test code this should not require test changes unless you want to test that a specific logger receives a specific message. Seems overkill.

**Question**

How is this project versioned? Do you use a tool that I can read about? Does this tool manage the changelog as well?