### PR TITLE
Docs: fix broken URL's, ignore a couple in sphynx cfg.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Overview
 
 .. |coveralls| image:: https://coveralls.io/repos/ionelmc/python-redis-lock/badge.svg?branch=master&service=github
     :alt: Coverage Status
-    :target: https://coveralls.io/r/ionelmc/python-redis-lock
+    :target: https://coveralls.io/github/ionelmc/python-redis-lock
 
 .. |codecov| image:: https://codecov.io/gh/ionelmc/python-redis-lock/branch/master/graphs/badge.svg?branch=master
     :alt: Coverage Status
@@ -63,7 +63,7 @@ Lock context manager implemented via redis SETNX/BLPOP.
 
 * Free software: BSD 2-Clause License
 
-Interface targeted to be exactly like `threading.Lock <http://docs.python.org/2/library/threading.html#threading.Lock>`_.
+Interface targeted to be exactly like `threading.Lock <https://docs.python.org/2/library/threading.html#threading.Lock>`_.
 
 Usage
 =====
@@ -120,7 +120,7 @@ Avoid dogpile effect in django
 The dogpile is also known as the thundering herd effect or cache stampede. Here's a pattern to avoid the problem
 without serving stale data. The work will be performed a single time and every client will wait for the fresh data.
 
-To use this you will need `django-redis <https://github.com/niwibe/django-redis>`_, however, ``python-redis-lock``
+To use this you will need `django-redis <https://github.com/jazzband/django-redis>`_, however, ``python-redis-lock``
 provides you a cache backend that has a cache method for your convenience. Just install ``python-redis-lock`` like
 this:
 
@@ -145,7 +145,7 @@ Now put something like this in your settings:
 .. note::
     If using a `django-redis` < `3.8.x`, you'll probably need `redis_cache`
     which has been deprecated in favor to `django_redis`. The `redis_cache`
-    module is removed in `django-redis` versions > `3.9.x`. See `django-redis notes <http://niwinz.github.io/django-redis/latest/#_configure_as_cache_backend>`_.
+    module is removed in `django-redis` versions > `3.9.x`. See `django-redis notes <https://github.com/jazzband/django-redis#configure-as-cache-backend>`_.
 
 
 This backend just adds a convenient ``.lock(name, expire=None)`` function to django-redis's cache backend.
@@ -215,13 +215,13 @@ Implementation
 
 This is how it works:
 
-.. image:: https://raw.github.com/ionelmc/python-redis-lock/master/docs/redis-lock%20diagram%20(v3.0).png
+.. image:: https://raw.githubusercontent.com/ionelmc/python-redis-lock/master/docs/redis-lock%20diagram%20(v3.0).png
     :alt: python-redis-lock flow diagram
 
 Documentation
 =============
 
-https://python-redis-lock.readthedocs.org/
+https://python-redis-lock.readthedocs.io/en/latest/
 
 Development
 ===========

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,13 +22,17 @@ author = 'Ionel Cristian Mărieș'
 copyright = '{0}, {1}'.format(year, author)
 version = release = '3.6.0'
 
+linkcheck_ignore = [
+    'https://coveralls\\.io/repos/ionelmc/python\\-redis\\-lock/badge\\.svg\\?branch=master\\&service=github',  # This redirects to hosted % image on AWS.
+    'https://github\\.com/jazzband/django\\-redis\\#configure\\-as\\-cache\\-backend',  # This anchor is incorrectly marked as missing. GH bug?
+]
 pygments_style = 'trac'
 templates_path = ['.']
 extlinks = {
     'issue': ('https://github.com/ionelmc/python-redis-lock/issues/%s', '#'),
     'pr': ('https://github.com/ionelmc/python-redis-lock/pull/%s', 'PR #'),
 }
-html_theme = "sphinx_py3doc_enhanced_theme"
+html_theme = 'sphinx_py3doc_enhanced_theme'
 html_theme_path = [sphinx_py3doc_enhanced_theme.get_html_theme_path()]
 html_theme_options = {
     'githuburl': 'https://github.com/ionelmc/python-redis-lock/'


### PR DESCRIPTION
As titile. Currently Travis is failing because of some errors with redirected URLs.

<img width="510" alt="Screen Shot 2020-11-16 at 12 34 13" src="https://user-images.githubusercontent.com/9869123/99293273-0abdea80-2808-11eb-9a42-7d7fec60d657.png">

No longer.

I had to ignore 2 URLs. I added brief comments explaining why.