### PR TITLE
fix docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ Another solution is to use the ``reset_all()`` function when the application sta
 
     # On application start/restart
     import redis_lock
-    redis_lock.reset_all()
+    redis_lock.reset_all(conn)
 
 Alternatively, you can reset individual locks via the ``reset`` method.
 


### PR DESCRIPTION
docs were missing the conn parameter to redis_lock.reset_all()