### PR TITLE
Set parameter for acquire

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,6 +50,14 @@ The above example could be rewritten using context manager::
         print("Got the lock. Doing some work ...")
         time.sleep(5)
 
+You can pass `blocking=False` parameter to the contex manager (default value
+is True, will raise a NotAcquired exception if lock won't be acquired)::
+
+    conn = StrictRedis()
+    with redis_lock.Lock(conn, "name-of-the-lock", blocking=False):
+        print("Got the lock. Doing some work ...")
+        time.sleep(5)
+
 In cases, where lock not necessarily in acquired state, and
 user need to ensure, that it has a matching ``id``, example::
 

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -341,6 +341,16 @@ def test_double_acquire(conn):
         pytest.raises(AlreadyAcquired, lock.acquire)
 
 
+def test_enter_already_acquired_with_not_blocking(conn):
+    lock = Lock(conn, "foobar")
+    acquired = lock.acquire()
+    assert acquired
+
+    with pytest.raises(NotAcquired):
+        with Lock(conn, "foobar", blocking=False):
+            pass
+
+
 def test_plain(conn):
     with Lock(conn, "foobar"):
         time.sleep(0.01)


### PR DESCRIPTION
Addressed this issue:
https://github.com/ionelmc/python-redis-lock/issues/67

So blocking flag can be passed on init and used later in the context manager.

Please let me know if something else should be done here.