### PR TITLE
fix test: ignore string case when waiting for redis-server 'ready to accept connections' message

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,5 +13,5 @@ def redis_server(tmp_path, redis_socket):
     with TestProcess(
         'redis-server', '--port', '0', '--save', '', '--appendonly', 'yes', '--dir', tmp_path, '--unixsocket', redis_socket
     ) as redis_server:
-        wait_for_strings(redis_server.read, 2, 'ready to accept connections')
+        wait_for_strings(redis_server.read, 2, 'ready to accept connections', ignore_case=True)
         yield redis_server


### PR DESCRIPTION
**This PR depends on and make use of the added option in:** 
https://github.com/ionelmc/python-process-tests/pull/7

As described in the other PR, this should solves the issue that certain version of redis-server (e.g., v7.2.5) outputs the following message when it's up and ready:
 `Ready to accept connections` instead of ` ready to accept connections`
which causing the tests to fail 